### PR TITLE
Fix windows path issues

### DIFF
--- a/src/postgres_model_context.rs
+++ b/src/postgres_model_context.rs
@@ -9,6 +9,28 @@ use zed_extension_api::{
 const PACKAGE_NAME: &str = "@zeddotdev/postgres-context-server";
 const SERVER_PATH: &str = "node_modules/@zeddotdev/postgres-context-server/index.mjs";
 
+/// Extensions to the Zed extension API that have not yet stabilized.
+mod zed_ext {
+    /// Sanitizes the given path to remove the leading `/` on Windows.
+    ///
+    /// On macOS and Linux this is a no-op.
+    ///
+    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
+    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
+        use zed_extension_api::{current_platform, Os};
+
+        let (os, _arch) = current_platform();
+        match os {
+            Os::Mac | Os::Linux => path,
+            Os::Windows => path
+                .to_string_lossy()
+                .to_string()
+                .trim_start_matches('/')
+                .into(),
+        }
+    }
+}
+
 struct PostgresModelContextExtension;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -39,13 +61,16 @@ impl zed::Extension for PostgresModelContextExtension {
         let settings: PostgresContextServerSettings =
             serde_json::from_value(settings).map_err(|e| e.to_string())?;
 
+        // Sanitize paths for Windows compatibility
+        let node_path = zed_ext::sanitize_windows_path(zed::node_binary_path()?.into());
+        let server_path = zed_ext::sanitize_windows_path(env::current_dir().unwrap())
+            .join(SERVER_PATH)
+            .to_string_lossy()
+            .to_string();
+
         Ok(Command {
-            command: zed::node_binary_path()?,
-            args: vec![env::current_dir()
-                .unwrap()
-                .join(SERVER_PATH)
-                .to_string_lossy()
-                .to_string()],
+            command: node_path.to_string_lossy().to_string(),
+            args: vec![server_path],
             env: vec![("DATABASE_URL".into(), settings.database_url)],
         })
     }


### PR DESCRIPTION
This fixes the issue in which the MCP server won't start in windows due to leading slash. The workaround has been documented here: https://github.com/bytecodealliance/wasmtime/issues/10415