### PR TITLE
Move `zed_ext` to the bottom

### DIFF
--- a/src/postgres_model_context.rs
+++ b/src/postgres_model_context.rs
@@ -9,28 +9,6 @@ use zed_extension_api::{
 const PACKAGE_NAME: &str = "@zeddotdev/postgres-context-server";
 const SERVER_PATH: &str = "node_modules/@zeddotdev/postgres-context-server/index.mjs";
 
-/// Extensions to the Zed extension API that have not yet stabilized.
-mod zed_ext {
-    /// Sanitizes the given path to remove the leading `/` on Windows.
-    ///
-    /// On macOS and Linux this is a no-op.
-    ///
-    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
-    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
-        use zed_extension_api::{current_platform, Os};
-
-        let (os, _arch) = current_platform();
-        match os {
-            Os::Mac | Os::Linux => path,
-            Os::Windows => path
-                .to_string_lossy()
-                .to_string()
-                .trim_start_matches('/')
-                .into(),
-        }
-    }
-}
-
 struct PostgresModelContextExtension;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -96,3 +74,25 @@ impl zed::Extension for PostgresModelContextExtension {
 }
 
 zed::register_extension!(PostgresModelContextExtension);
+
+/// Extensions to the Zed extension API that have not yet stabilized.
+mod zed_ext {
+    /// Sanitizes the given path to remove the leading `/` on Windows.
+    ///
+    /// On macOS and Linux this is a no-op.
+    ///
+    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
+    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
+        use zed_extension_api::{current_platform, Os};
+
+        let (os, _arch) = current_platform();
+        match os {
+            Os::Mac | Os::Linux => path,
+            Os::Windows => path
+                .to_string_lossy()
+                .to_string()
+                .trim_start_matches('/')
+                .into(),
+        }
+    }
+}


### PR DESCRIPTION
As we plan on eventually removing this, it makes more sense to have this at the bottom of the file