### PR TITLE
Bump version to v0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "zed_postgres_model_context"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_postgres_model_context"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "postgres-context-server"
 name = "Postgres Context Server"
 description = "Model Context Server for PostgreSQL"
-version = "0.0.3"
+version = "0.0.4"
 schema_version = 1
 authors = ["Max Brunsfeld <max@zed.dev>"]
 repository = "https://github.com/zed-extensions/postgres-context-server"


### PR DESCRIPTION
This PR bumps the version of the extension to v0.0.4.

Includes:

- https://github.com/zed-extensions/postgres-context-server/pull/10